### PR TITLE
fix: minor UX fixes for installing extensions (#4308)

### DIFF
--- a/Composer/packages/client/src/pages/setting/SettingsPage.tsx
+++ b/Composer/packages/client/src/pages/setting/SettingsPage.tsx
@@ -89,8 +89,6 @@ const SettingPage: React.FC<RouteComponentProps> = () => {
   useEffect(() => {
     if (!projectId && location.pathname.indexOf('/settings/bot/') !== -1) {
       navigate('/settings/application');
-    } else {
-      navigate(links[0].url);
     }
   }, [projectId]);
 

--- a/Composer/packages/client/src/pages/setting/extensions/ExtensionSearchResults.tsx
+++ b/Composer/packages/client/src/pages/setting/extensions/ExtensionSearchResults.tsx
@@ -3,7 +3,7 @@
 
 /** @jsx jsx */
 import { jsx, css } from '@emotion/core';
-import React from 'react';
+import React, { useRef } from 'react';
 import formatMessage from 'format-message';
 import {
   DetailsListLayoutMode,
@@ -11,6 +11,7 @@ import {
   IColumn,
   CheckboxVisibility,
   ConstrainMode,
+  Selection,
 } from 'office-ui-fabric-react/lib/DetailsList';
 import { ScrollablePane } from 'office-ui-fabric-react/lib/ScrollablePane';
 import { Sticky } from 'office-ui-fabric-react/lib/Sticky';
@@ -44,6 +45,13 @@ const noResultsStyles = css`
 
 const ExtensionSearchResults: React.FC<ExtensionSearchResultsProps> = (props) => {
   const { results, isSearching, onSelect } = props;
+  const selection = useRef(
+    new Selection({
+      onSelectionChanged: () => {
+        onSelect(selection.getSelection()[0] as ExtensionSearchResult);
+      },
+    })
+  ).current;
 
   const searchColumns: IColumn[] = [
     {
@@ -101,9 +109,9 @@ const ExtensionSearchResults: React.FC<ExtensionSearchResultsProps> = (props) =>
           enableShimmer={isSearching}
           items={noResultsFound ? [{}] : results}
           layoutMode={DetailsListLayoutMode.justified}
+          selection={selection}
           selectionMode={SelectionMode.single}
           shimmerLines={8}
-          onActiveItemChanged={(item) => onSelect(item)}
           onRenderDetailsHeader={(headerProps, defaultRender) => {
             if (defaultRender) {
               return <Sticky>{defaultRender(headerProps)}</Sticky>;

--- a/Composer/packages/client/src/pages/setting/extensions/Extensions.tsx
+++ b/Composer/packages/client/src/pages/setting/extensions/Extensions.tsx
@@ -158,15 +158,15 @@ const Extensions: React.FC<RouteComponentProps> = () => {
   }, []);
 
   const shownItems = () => {
-    if (extensions.length === 0) {
-      // render no installed message
-      return [{}];
-    } else if (isUpdating === true) {
+    if (isUpdating === true) {
       // extension is being added, render a shimmer row at end of list
       return [...extensions, null];
     } else if (typeof isUpdating === 'string') {
       // extension is being removed or updated, show shimmer for that row
       return extensions.map((e) => (e.id === isUpdating ? null : e));
+    } else if (extensions.length === 0) {
+      // render no installed message
+      return [{}];
     } else {
       return extensions;
     }
@@ -186,20 +186,25 @@ const Extensions: React.FC<RouteComponentProps> = () => {
         selection={selection}
         selectionMode={SelectionMode.multiple}
         onRenderRow={(rowProps, defaultRender) => {
-          if (extensions.length === 0) {
-            return (
-              <div css={noExtensionsStyles}>
-                <p>{formatMessage('No extensions installed')}</p>
-              </div>
-            );
-          }
+          if (rowProps && defaultRender) {
+            if (isUpdating) {
+              return defaultRender(rowProps);
+            }
 
-          if (defaultRender && rowProps) {
+            if (extensions.length === 0) {
+              return (
+                <div css={noExtensionsStyles}>
+                  <p>{formatMessage('No extensions installed')}</p>
+                </div>
+              );
+            }
+
             const customStyles: Partial<IDetailsRowStyles> = {
               root: {
-                color: rowProps?.item?.enabled ? undefined : NeutralColors.gray90,
+                color: rowProps.item?.enabled ? undefined : NeutralColors.gray90,
               },
             };
+
             return <DetailsRow {...rowProps} styles={customStyles} />;
           }
 

--- a/Composer/packages/client/src/pages/setting/extensions/InstallExtensionDialog.tsx
+++ b/Composer/packages/client/src/pages/setting/extensions/InstallExtensionDialog.tsx
@@ -96,7 +96,7 @@ const InstallExtensionDialog: React.FC<InstallExtensionDialogProps> = (props) =>
       </div>
       <DialogFooter>
         <DefaultButton onClick={onDismiss}>Cancel</DefaultButton>
-        <PrimaryButton disabled={false} onClick={onSubmit}>
+        <PrimaryButton disabled={!selectedExtension} onClick={onSubmit}>
           {formatMessage('Add')}
         </PrimaryButton>
       </DialogFooter>

--- a/Composer/packages/client/src/recoilModel/types.ts
+++ b/Composer/packages/client/src/recoilModel/types.ts
@@ -46,6 +46,8 @@ type ExtensionPublishContribution = {
 };
 
 export type ExtensionPageContribution = {
+  /** plugin id */
+  id: string;
   bundleId: string;
   label: string;
   icon?: string;

--- a/Composer/packages/client/src/utils/hooks.ts
+++ b/Composer/packages/client/src/utils/hooks.ts
@@ -33,7 +33,7 @@ export const useLinks = () => {
   const pluginPages = extensions.reduce((pages, p) => {
     const pagesConfig = p.contributes?.views?.pages;
     if (Array.isArray(pagesConfig) && pagesConfig.length > 0) {
-      pages.push(...pagesConfig);
+      pages.push(...pagesConfig.map((page) => ({ ...page, id: p.id })));
     }
     return pages;
   }, [] as ExtensionPageContribution[]);

--- a/Composer/packages/client/src/utils/pageLinks.ts
+++ b/Composer/packages/client/src/utils/pageLinks.ts
@@ -72,7 +72,7 @@ export const topLinks = (projectId: string, openedDialogId: string, pluginPages:
   if (pluginPages.length > 0) {
     pluginPages.forEach((p) => {
       links.push({
-        to: `page/${p.bundleId}`,
+        to: `page/${p.id}`,
         iconName: p.icon ?? 'StatusCircleQuestionMark',
         labelName: p.label,
         exact: true,

--- a/Composer/packages/extension/src/utils/npm.ts
+++ b/Composer/packages/extension/src/utils/npm.ts
@@ -12,7 +12,7 @@ type NpmOutput = {
   stderr: string;
   code: number;
 };
-type NpmCommand = 'install' | 'uninstall' | 'search';
+type NpmCommand = 'install' | 'uninstall' | 'search' | 'link';
 type NpmOptions = {
   [key: string]: string;
 };

--- a/Composer/packages/server/src/controllers/extensions.ts
+++ b/Composer/packages/server/src/controllers/extensions.ts
@@ -9,6 +9,7 @@ interface AddExtensionRequest extends Request {
   body: {
     id?: string;
     version?: string;
+    path?: string;
   };
 }
 
@@ -60,10 +61,15 @@ export async function addExtension(req: AddExtensionRequest, res: Response) {
     return;
   }
 
-  await ExtensionManager.installRemote(id, version);
-  await ExtensionManager.load(id);
-  const extension = ExtensionManager.find(id);
-  res.json(presentExtension(extension));
+  const extensionId = await ExtensionManager.installRemote(id, version);
+
+  if (extensionId) {
+    await ExtensionManager.load(extensionId);
+    const extension = ExtensionManager.find(extensionId);
+    res.json(presentExtension(extension));
+  } else {
+    res.status(500).json({ error: 'Unable to install extension.' });
+  }
 }
 
 export async function toggleExtension(req: ToggleExtensionRequest, res: Response) {


### PR DESCRIPTION
* use plugin id for page links

* add api to install local extension

* disable add button when no extension selected

* fix settings page redirect issue

* normalize search query for extensions

* revert api to install local extension

* fix shimmer row when no extensions installed

* add test for unsuccessul install

* fix type error

## Description

<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

If this is a bug fix, please describe the root cause and analysis of this problem.
---->

## Task Item

<!---
Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)
---->

## Screenshots

<!---
Please include screenshots or gifs if your PR include UX changes.
--->
